### PR TITLE
Ensures multiple works correctly in 2.2 and above

### DIFF
--- a/field.multiple.php
+++ b/field.multiple.php
@@ -341,10 +341,11 @@ class Field_multiple
 
 		if (is_numeric($entry_id))
 		{
-			$this->CI->db->where('jt.row_id', $entry_id, false);
-			$this->CI->db->from($join_table.' AS jt');
-$this->CI->db->join($stream->stream_prefix.$stream->stream_slug, 'jt.'.$stream->stream_slug.'_id = '.$stream->stream_prefix.$stream->stream_slug.'.id');
-			$query = $this->CI->db->get();
+
+			$query = $this->CI->db->from($join_table.' AS jt')
+								  ->join($stream->stream_prefix.$stream->stream_slug, 'jt.'.$stream->stream_slug.'_id = '.$stream->stream_prefix.$stream->stream_slug.'.id')
+								  ->where('jt.row_id', $entry_id, false)
+								  ->get();
 
 			foreach ($query->result() as $node)
 			{

--- a/views/sort_table.php
+++ b/views/sort_table.php
@@ -2,7 +2,7 @@
 
 	if(!defined('PYROSTREAMS_MULT_JS_LOADED')):
 		
-		if (substr(CMS_VERSION, 0, 3) == '2.1') {
+		if (substr(CMS_VERSION, 0, 3) >= '2.1') {
 			$streams = 'streams_core';
 		}
 		else {


### PR DESCRIPTION
Simple change to keep Multiple looking in the right place for asset loading, otherwise the Javascript is missing and causes all other js elements on the page to not load or work correctly.
