### PR TITLE
Solves a problem when editing entries with multiple fields

### DIFF
--- a/field.multiple.php
+++ b/field.multiple.php
@@ -114,8 +114,8 @@ class Field_multiple
 
 		$html = '<ul>';
 				
-		$this->CI->db->where('jt.row_id', $row_id, FALSE);
 		$this->CI->db->from($join_table.' AS jt');
+		$this->CI->db->where('jt.row_id', $row_id, false);
 		$this->CI->db->join($stream->stream_prefix.$join_stream->stream_slug, 'jt.'.$join_stream->stream_slug.'_id = '.$stream->stream_prefix.$join_stream->stream_slug.'.id');
 		$query = $this->CI->db->get();
 		


### PR DESCRIPTION
Error Number: 1054

Unknown column 'default_jt.row_id' in 'where clause'

SELECT \* FROM `default_faq_faqs_departements` AS `jt` JOIN `default_faq_departements` ON `jt`.`departements_id` = `default_faq_departements`.`id` WHERE default_jt.row_id = 3
