### PR TITLE
missing stream prefix

### DIFF
--- a/field.multiple.php
+++ b/field.multiple.php
@@ -194,9 +194,9 @@ class Field_multiple
 
 		// Our binding table.
 		if ($field->field_namespace == 'pages') {
-			$join_table = $field->field_namespace.'_'.$attributes['stream_slug'].'_'.$join_stream->stream_slug;
+			$join_table = $field->field_namespace.'_'.$join_stream->stream_prefix.$attributes['stream_slug'].'_'.$join_stream->stream_slug;
 		} else {
-			$join_table = $attributes['stream_slug'].'_'.$join_stream->stream_slug;
+			$join_table = $join_stream->stream_prefix.$attributes['stream_slug'].'_'.$join_stream->stream_slug;
 		}
 
 		$params = array(


### PR DESCRIPTION
I was getting an sql error when calling multiple from a template:

> Table 'db_name.default_clinic_physician' doesn't exist

the markup looked like this:

``` html
{{ streams:single stream="clinic" where="..." }}
    {{ physicians order_by="sort_name" limit="999" }}
        ...
    {{ /physicians }}
{{ /streams:single }}
```

actual table name was `default_str_clinic_physician` so I added the stream prefix and it fixed it. wasn't able to test the field_namespace == 'pages' condition, but I think I put it in the right place
