### PR TITLE
Fixes issue #28 - Bug when using Stream prefixes

### DIFF
--- a/field.multiple.php
+++ b/field.multiple.php
@@ -147,7 +147,7 @@ class Field_multiple
 		$title_column = $join_stream->title_column;
 		
 		// Default to ID for title column if not present
-		if ( ! trim($title_column) or ! $this->CI->db->field_exists($title_column, $stream->stream_prefix.$join_stream->stream_slug))
+		if ( ! trim($title_column) or ! $this->CI->db->field_exists($title_column, $join_stream->stream_prefix.$join_stream->stream_slug))
 		{
 			$title_column = 'id';
 		}
@@ -167,7 +167,7 @@ class Field_multiple
 		$html = '<ul>';
 
 		$this->CI->db->from($join_table.' AS jt');
-		$this->CI->db->join($stream->stream_prefix.$join_stream->stream_slug, 'jt.'.$join_stream->stream_slug.'_id = '.$stream->stream_prefix.$join_stream->stream_slug.'.id');
+		$this->CI->db->join($join_stream->stream_prefix.$join_stream->stream_slug, 'jt.'.$join_stream->stream_slug.'_id = '.$join_stream->stream_prefix.$join_stream->stream_slug.'.id');
 		$this->CI->db->where('jt.row_id', $row_id, false);
 		$query = $this->CI->db->get();
 		


### PR DESCRIPTION
Fixes issue #28

Another way to reproduce this bug is assigning a Multiple field to a stream that has a prefix. If you choose the Profile stream as your join table in the Multiple field type it would cause an error because profiles doesn't have a prefix and it was incorrectly getting prepended in the alt_pre_output() function. This PR fixes the issue.
